### PR TITLE
feat: Add interactive mode for direct script execution

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -1,0 +1,124 @@
+"""
+Provides image manipulation functions for pixelating and dithering images.
+
+This module contains functions to apply pixelation and Floyd-Steinberg
+dithering effects to images using the Pillow library. It can be imported
+into other Python scripts to use its functions directly:
+  - pixelate_image(image, pixel_size)
+  - dither_image(image, palette_size=16)
+  - pixelate_and_dither_image(input_path, output_path, pixel_size, palette_size=16)
+
+Alternatively, this script can be run directly from the command line
+(e.g., `python image_utils.py`). When run as a script, it will interactively
+prompt the user for the input image path, output image path, pixel size,
+and palette size, and then process the image accordingly.
+"""
+from PIL import Image
+import sys # Added for sys.exit()
+
+def pixelate_image(image, pixel_size):
+  """Pixelates a Pillow Image object.
+
+  Args:
+    image: A Pillow Image object.
+    pixel_size: The size of the pixels in the pixelated image.
+
+  Returns:
+    A Pillow Image object representing the pixelated image.
+  """
+  original_width, original_height = image.size
+
+  # Calculate new dimensions, ensuring they are at least 1
+  new_width = max(1, original_width // pixel_size)
+  new_height = max(1, original_height // pixel_size)
+
+  # Resize down
+  downscaled_image = image.resize((new_width, new_height), Image.Resampling.BILINEAR)
+
+  # Resize up
+  pixelated_image = downscaled_image.resize((original_width, original_height), Image.Resampling.NEAREST)
+
+  return pixelated_image
+
+def dither_image(image, palette_size=16):
+  """Applies Floyd-Steinberg dithering to a Pillow Image object.
+
+  Args:
+    image: A Pillow Image object.
+    palette_size: The number of colors for quantization. Defaults to 16.
+
+  Returns:
+    A Pillow Image object representing the dithered image.
+  """
+  # Method 2 in quantize typically corresponds to Floyd-Steinberg dithering.
+  dithered_image = image.quantize(colors=palette_size, method=2)
+  return dithered_image
+
+def pixelate_and_dither_image(input_path, output_path, pixel_size, palette_size=16):
+  """Opens an image, pixelates it, dithers it, and saves the result.
+
+  Args:
+    input_path: Path to the input image file.
+    output_path: Path to save the processed image file.
+    pixel_size: The size of the pixels for pixelation.
+    palette_size: The number of colors for dithering quantization. Defaults to 16.
+  
+  Side effects:
+    - Prints error messages to stdout if file operations fail.
+    - Saves the processed image to output_path if successful.
+  """
+  try:
+    img = Image.open(input_path)
+  except FileNotFoundError:
+    print(f"Error: Input file not found at '{input_path}'")
+    return
+  except IOError:
+    print(f"Error: Could not open or read input image at '{input_path}'")
+    return
+  except Exception as e:
+    print(f"An unexpected error occurred while opening the image: {e}")
+    return
+
+  # Process the image
+  pixelated_img = pixelate_image(img, pixel_size)
+  dithered_pixelated_img = dither_image(pixelated_img, palette_size)
+
+  try:
+    dithered_pixelated_img.save(output_path)
+    print(f"Successfully processed and saved image to '{output_path}'")
+  except IOError:
+    print(f"Error: Could not save image to '{output_path}'")
+  except Exception as e:
+    print(f"An unexpected error occurred while saving the image: {e}")
+
+if __name__ == '__main__':
+  input_path_str = input("Enter the path to the input image: ")
+  output_path_str = input("Enter the path to save the output image: ")
+  pixel_size_str = input("Enter the pixel size (e.g., 8): ")
+  palette_size_str = input("Enter the palette size (number of colors, e.g., 16, press Enter for default 16): ")
+
+  # Validate pixel_size
+  try:
+    pixel_size_int = int(pixel_size_str)
+    if pixel_size_int <= 0:
+      print("Error: Pixel size must be a positive integer.")
+      sys.exit(1)
+  except ValueError:
+    print("Error: Pixel size must be a number.")
+    sys.exit(1)
+
+  # Validate palette_size
+  if not palette_size_str: # Check if the string is empty
+    palette_size_int = 16 # Default value
+  else:
+    try:
+      palette_size_int = int(palette_size_str)
+      if palette_size_int <= 0:
+        print("Error: Palette size must be a positive integer.")
+        sys.exit(1)
+    except ValueError:
+      print("Error: Palette size must be a number.")
+      sys.exit(1)
+
+  # Call the main processing function with validated inputs
+  pixelate_and_dither_image(input_path_str, output_path_str, pixel_size_int, palette_size_int)

--- a/test_image_utils.py
+++ b/test_image_utils.py
@@ -1,0 +1,133 @@
+import unittest
+import os
+from PIL import Image
+from unittest.mock import patch
+
+# Assuming image_utils.py is in the same directory or accessible via PYTHONPATH
+import image_utils
+
+class TestImageUtils(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        self.test_input_filename = "test_input.png"
+        self.test_output_filename = "test_output.png"
+
+        # Create a simple 16x16 image with two colors (half red, half blue)
+        img = Image.new('RGB', (16, 16))
+        pixels = img.load()
+        for i in range(16):
+            for j in range(16):
+                if j < 8:
+                    pixels[i, j] = (255, 0, 0)  # Red
+                else:
+                    pixels[i, j] = (0, 0, 255)  # Blue
+        img.save(self.test_input_filename)
+        self.input_image = Image.open(self.test_input_filename)
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+        if os.path.exists(self.test_input_filename):
+            os.remove(self.test_input_filename)
+        if os.path.exists(self.test_output_filename):
+            os.remove(self.test_output_filename)
+        self.input_image.close()
+
+    # --- Tests for pixelate_image ---
+    def test_pixelate_returns_image_object(self):
+        pixelated_img = image_utils.pixelate_image(self.input_image, 4)
+        self.assertIsInstance(pixelated_img, Image.Image)
+
+    def test_pixelate_output_dimensions(self):
+        pixelated_img = image_utils.pixelate_image(self.input_image, 4)
+        self.assertEqual(pixelated_img.size, self.input_image.size)
+
+    def test_pixelate_effect(self):
+        pixel_size = 4
+        pixelated_img = image_utils.pixelate_image(self.input_image, pixel_size)
+        # Check the color of the top-left pixel block
+        block_color = pixelated_img.getpixel((0, 0))
+        for i in range(pixel_size):
+            for j in range(pixel_size):
+                self.assertEqual(pixelated_img.getpixel((i, j)), block_color, 
+                                 f"Pixel at ({i},{j}) does not match block color.")
+
+    def test_pixelate_size_one(self):
+        # With pixel_size=1, the image should be very similar (though not necessarily identical due to processing)
+        pixelated_img = image_utils.pixelate_image(self.input_image, 1)
+        # A simple check is to compare a few sample pixels or a histogram if complex.
+        # For now, let's check dimensions and that it's not a completely different image.
+        self.assertEqual(pixelated_img.size, self.input_image.size)
+        # Compare a sample pixel - it should be very close if not identical
+        # Note: Bilinear downscale then nearest upscale can alter pixels even at size 1
+        # A more robust test might involve image difference metrics, but this is a basic check.
+        original_pixel = self.input_image.getpixel((0,0))
+        pixelated_pixel = pixelated_img.getpixel((0,0))
+        # Allowing for some minor difference due to resampling
+        self.assertTrue(
+            all(abs(original_pixel[k] - pixelated_pixel[k]) < 10 for k in range(3)),
+            "Pixel color changed significantly with pixel_size=1"
+        )
+
+
+    # --- Tests for dither_image ---
+    def test_dither_returns_image_object(self):
+        dithered_img = image_utils.dither_image(self.input_image, 16)
+        self.assertIsInstance(dithered_img, Image.Image)
+
+    def test_dither_output_mode_palettized(self):
+        dithered_img = image_utils.dither_image(self.input_image, 16)
+        self.assertEqual(dithered_img.mode, 'P', "Image mode should be 'P' (palettized).")
+
+    def test_dither_palette_size(self):
+        palette_size_target = 8 # Test with a smaller palette
+        dithered_img = image_utils.dither_image(self.input_image, palette_size_target)
+        palette = dithered_img.getpalette()
+        self.assertIsNotNone(palette)
+        # Number of colors in palette. Palette is a flat list [r,g,b,r,g,b,...]
+        num_colors = len(palette) // 3
+        self.assertLessEqual(num_colors, palette_size_target)
+        # Also ensure there are some colors, not an empty palette (unless palette_size_target is 0 or 1)
+        if palette_size_target > 0:
+            self.assertGreater(num_colors, 0, "Dithered image has no colors in its palette.")
+
+
+    # --- Tests for pixelate_and_dither_image (Integration) ---
+    def test_process_creates_output_file(self):
+        image_utils.pixelate_and_dither_image(self.test_input_filename, self.test_output_filename, 4, 16)
+        self.assertTrue(os.path.exists(self.test_output_filename))
+
+    @patch('builtins.print') # Mock print to capture stdout/stderr messages
+    def test_process_handles_nonexistent_input(self, mock_print):
+        non_existent_input = "non_existent_image.png"
+        image_utils.pixelate_and_dither_image(non_existent_input, self.test_output_filename, 4, 16)
+        
+        # Check that an error message was printed (order of calls might vary)
+        # Example: "Error: Input file not found at 'non_existent_image.png'"
+        # We assert that at least one call to print contains "Error: Input file not found"
+        error_message_found = False
+        for call_args in mock_print.call_args_list:
+            if "Error: Input file not found" in call_args[0][0]:
+                error_message_found = True
+                break
+        self.assertTrue(error_message_found, "Error message for non-existent input not printed.")
+        self.assertFalse(os.path.exists(self.test_output_filename), "Output file should not be created on input error.")
+
+    def test_process_output_image_properties(self):
+        image_utils.pixelate_and_dither_image(self.test_input_filename, self.test_output_filename, 4, 16)
+        self.assertTrue(os.path.exists(self.test_output_filename))
+        try:
+            processed_img = Image.open(self.test_output_filename)
+            self.assertEqual(processed_img.mode, 'P', "Processed image mode should be 'P'.")
+            # Check dimensions match original
+            self.assertEqual(processed_img.size, self.input_image.size, "Processed image dimensions do not match input.")
+        except FileNotFoundError:
+            self.fail(f"Output file {self.test_output_filename} was not created.")
+        except Exception as e:
+            self.fail(f"Error opening or validating processed image: {e}")
+        finally:
+            if 'processed_img' in locals():
+                processed_img.close()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit reintroduces the ability to run `image_utils.py` directly. When executed, the script now interactively prompts you for necessary parameters: input file path, output file path, pixel size, and palette size.

Key changes:
- Added an `if __name__ == '__main__':` block.
- Implemented input prompts using `input()`.
- Added validation for your provided pixel size and palette size, including error handling for invalid inputs and a default for palette size.
- The validated inputs are used to call the existing `pixelate_and_dither_image` function.
- Updated documentation with a module-level docstring explaining both library usage and direct interactive execution.

This change allows you to easily use the image processing functionality without needing to write a separate script, by simply running `python image_utils.py` and following the prompts. The script retains its capability to be used as a library.